### PR TITLE
Add CDL files detection

### DIFF
--- a/ftdetect/spice.vim
+++ b/ftdetect/spice.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.spc,*.sp set filetype=spice
+au BufNewFile,BufRead *.spc,*.sp,*.cdl set filetype=spice


### PR DESCRIPTION
This adds CDL files to ftdetect, to have them (not really correctly, but better than nothing) highlighted.